### PR TITLE
Use triage and maintain roles

### DIFF
--- a/config/github-teams.yml
+++ b/config/github-teams.yml
@@ -2,13 +2,13 @@
 - name: emeritus
   description: Past members of the @:org organization team
   scope: :org/*
-  permission: READ
+  permission: TRIAGE
   member: :orgTeam/emeritus
   maintainer: :orgTeam/releaser
 - name: members
   description: The @:org organization team
   scope: :org/*
-  permission: READ
+  permission: TRIAGE
   member: :orgTeam/!emeritus
   maintainer: :orgTeam/releaser
 - name: mergers
@@ -22,7 +22,7 @@
   parent: members
   description: '@:org members with release rights'
   scope: :org/*
-  permission: ADMIN
+  permission: MAINTAIN
   member: :orgTeam/releaser
   maintainer: :orgTeam/lead
 - name: moderators


### PR DESCRIPTION
This changes:

* Readers (currently emeriti, but in the future also contributors) to
  become triagers, allowing them to perform the following actions:
  * Apply labels
  * Close, reopen, and assign all issues and pull requests
* Releasers to become maintainers, preventing them from performing the
  following actions (abbreviated):
  * Manage outside collaborator access to a repository
  * Manage team and collaborator access to the repository
  * Delete or transfer repositories out of the organization

See: <https://github.blog/changelog/2019-05-23-triage-and-maintain-roles-beta/>

Closes unifiedjs/governance#18.
Closes GH-3.

<!--
Read the [contributing guidelines](https://github.com/unifiedjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/unifiedjs/.github/blob/master/support.md
https://github.com/unifiedjs/.github/blob/master/contributing.md
-->
