### PR TITLE
Add support for automating labels

### DIFF
--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -17,7 +17,6 @@ add:
         description: This affects dependencies
         legacy:
           - dependencies # MDXs old labels
-          - area/dependencies # Prev
       - name: 📚 area/docs
         description: This affects documentation
         legacy:
@@ -35,15 +34,12 @@ add:
         description: This affects the hidden internals
       - name: 🏁 area/perf
         description: This affects performance
-        legacy:
-          - area/performance # Prev
       - name: 🔒 area/security
         description: This affects security
       - name: 🕸️ area/tests
         description: This affects tests
         legacy:
           - reproduction # MDXs
-          - area/test # Prev
       - name: 🏗 area/tools
         description: This affects tooling
       - name: ☂️ area/types

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -32,10 +32,11 @@ add:
         description: This affects performance
       - name: 🔒 area/security
         description: This affects security
-      - name: 🕸️ area/test
+      - name: 🕸️ area/tests
         description: This affects tests
         legacy:
           - reproduction # MDXs
+          - area/test # Prev
       - name: 🏗 area/tools
         description: This affects tooling
       - name: ☂️ area/types

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -31,6 +31,8 @@ add:
         description: This affects community
       - name: 🗄 area/interface
         description: This affects the public interface
+      - name: 🏡 area/internal
+        description: This affects the hidden internals
       - name: 🏁 area/perf
         description: This affects performance
         legacy:

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -13,10 +13,11 @@ add:
       from: hsl(212, 97%, 58%)
       to: hsl(212, 97%, 88%)
     labels:
-      - name: 📦 area/dependencies
+      - name: 📦 area/deps
         description: This affects dependencies
         legacy:
           - dependencies # MDXs old labels
+          - area/dependencies # Prev
       - name: 📚 area/docs
         description: This affects documentation
         legacy:

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -23,7 +23,7 @@ add:
         legacy:
           - docs # MDXs old labels
       - name: 👀 area/external
-        description: This affects something outside of the project
+        description: This makes more sense somewhere else
         legacy:
           - external # wooorm’s old labels
           - not in core # wooorm’s old labels

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -27,6 +27,8 @@ add:
         legacy:
           - external # wooorm’s old labels
           - not in core # wooorm’s old labels
+      - name: 👩‍⚕ area/health
+        description: This affects community
       - name: 🗄 area/interface
         description: This affects the public interface
       - name: 🏁 area/perf

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -28,8 +28,10 @@ add:
           - not in core # wooorm’s old labels
       - name: 🗄 area/interface
         description: This affects the public interface
-      - name: 🏁 area/performance
+      - name: 🏁 area/perf
         description: This affects performance
+        legacy:
+          - area/performance # Prev
       - name: 🔒 area/security
         description: This affects security
       - name: 🕸️ area/tests

--- a/config/github-labels.yml
+++ b/config/github-labels.yml
@@ -1,0 +1,152 @@
+# List of labels to remove: we’re not using anything like this anymore.
+remove:
+  - greenkeeper
+  - has pr
+  - needs pr
+  - priority
+  - low priority
+# List of labels to add.
+# Can be groups, as that allows color scaling (or defining a color once)
+# Each label can have a list of `legacy` labels, which are replaced.
+add:
+  - color:
+      from: hsl(212, 97%, 58%)
+      to: hsl(212, 97%, 88%)
+    labels:
+      - name: 📦 area/dependencies
+        description: This affects dependencies
+        legacy:
+          - dependencies # MDXs old labels
+      - name: 📚 area/docs
+        description: This affects documentation
+        legacy:
+          - docs # MDXs old labels
+      - name: 👀 area/external
+        description: This affects something outside of the project
+        legacy:
+          - external # wooorm’s old labels
+          - not in core # wooorm’s old labels
+      - name: 🗄 area/interface
+        description: This affects the public interface
+      - name: 🏁 area/performance
+        description: This affects performance
+      - name: 🔒 area/security
+        description: This affects security
+      - name: 🕸️ area/test
+        description: This affects tests
+        legacy:
+          - reproduction # MDXs
+      - name: 🏗 area/tools
+        description: This affects tooling
+      - name: ☂️ area/types
+        description: This affects typings
+  - color:
+      from: hsl(0, 97%, 58%)
+      to: hsl(0, 97%, 88%)
+    labels:
+      - name: 🌊 blocked/upstream
+        description: This cannot progress before something external happens first
+        legacy:
+          - upstream # MDXs
+      - name: 🗳 blocked/vote
+        description: This cannot progress before voting is complete
+      - name: 🛠 blocked/wip
+        description: This cannot progress yet, it’s being worked on
+  - color:
+      from: hsl(45, 97%, 58%)
+      to: hsl(45, 97%, 88%)
+    labels:
+      - name: 👶 semver/patch
+        description: This is a backwards-compatible fix
+        legacy:
+          - patch # wooorm’s old labels
+      - name: 🧒 semver/minor
+        description: This is backwards-compatible change
+        legacy:
+          - feature # wooorm’s old labels
+          - minor # wooorm’s old labels
+      - name: 🧑 semver/major
+        description: This is a change
+        legacy:
+          - change # wooorm’s old labels
+          - major # wooorm’s old labels
+  - color:
+      from: hsl(300, 97%, 58%)
+      to: hsl(300, 97%, 88%)
+    labels:
+      - name: 🙆 status/confirmed
+        description: 'This is open and confirmed: ready to be worked on'
+        legacy:
+          - rfc accepted # MDXs old labels
+          - investigation # MDXs old labels
+      - name: 🥂 status/merged
+        description: This is done!
+      - name: 🔍 status/open
+        description: This is new!
+      - name: ⛵️ status/released
+        description: This is released
+      - name: 🧘 status/waiting
+        description: This may go somewhere but needs more information
+        legacy:
+          - future # wooorm’s old labels
+          - concept # wooorm’s old labels
+          - awaiting response # MDXs old labels
+      - name: 🚫 status/wontfix
+        description: This is not (enough of) an issue for this project
+        legacy:
+          - wontfix # Default GitHub name
+  - color:
+      from: hsl(160, 97%, 58%)
+      to: hsl(160, 97%, 88%)
+    labels:
+      - name: 📣 type/announcement
+        description: This is meta
+      - name: 💬 type/discussion
+        description: This is a request for comments
+        legacy:
+          - discussion # MDXs labels
+          - rfc # MDXs labels
+      - name: 🙋 type/question
+        description: This does not need any changes
+        legacy:
+          - question # Default GitHub name, wooorm’s old labels, MDXs
+      - name: 🐛 type/bug
+        description: This is a problem
+        legacy:
+          - bug # Default GitHub name, wooorm’s old labels, and MDXs
+      - name: 🦋 type/enhancement
+        description: This is great to have
+        legacy:
+          - enhancement # Default GitHub name, wooorm’s old labels, and MDXs
+  - color:
+      from: hsl(120, 97%, 58%)
+      to: hsl(120, 97%, 88%)
+    labels:
+      - name: 🌐 platform/browser
+        description: This affects browsers
+      - name: 🐧 platform/linux
+        description: This affects Linux
+      - name: 🍏 platform/macos
+        description: This affects macOS
+      - name: 🐢 platform/node
+        description: This affects Node
+      - name: 📎 platform/windows
+        description: This affects Windows
+  - name: good first issue 👋
+    color: black
+    description: This may be a great place to get started!
+    legacy:
+      - good for beginner # wooorm’s old labels
+  - name: help wanted 🙏
+    color: black
+    description: This could use your insight or help
+    legacy:
+      - help # Default GitHub name
+  - name: duplicate 👯
+    color: black
+    description: Déjà vu
+  - name: invalid 🙅
+    color: black
+    description: This cannot be acted upon
+    legacy:
+      - no # wooorm’s old labels

--- a/config/github-organizations.yml
+++ b/config/github-organizations.yml
@@ -3,18 +3,18 @@ owner: core/!emeritus
 orgs:
   - github: unifiedjs
     unified: unified
-  - github: remarkjs
-    unified: remark
-  - github: rehypejs
-    unified: rehype
-  - github: retextjs
-    unified: retext
-  - github: redotjs
-    unified: redot
-  - github: mdx-js
-    unified: mdx
-  - github: micromark
-    unified: micromark
+  # - github: remarkjs
+  #   unified: remark
+  # - github: rehypejs
+  #   unified: rehype
+  # - github: retextjs
+  #   unified: retext
+  # - github: redotjs
+  #   unified: redot
+  # - github: mdx-js
+  #   unified: mdx
+  # - github: micromark
+  #   unified: micromark
   - github: syntax-tree
     unified: syntax tree
   - github: vfile

--- a/config/index.js
+++ b/config/index.js
@@ -12,6 +12,7 @@ exports.teams = load('unified-teams')
 exports.ghOrgs = load('github-organizations')
 exports.ghTeams = load('github-teams')
 exports.ghHumans = load('github-humans')
+exports.ghLabels = load('github-labels')
 
 function load(name) {
   return yaml.safeLoad(fs.readFileSync(path.join('config', name + '.yml')))

--- a/lib/collective/index.js
+++ b/lib/collective/index.js
@@ -2,8 +2,10 @@
 
 const trough = require('trough')
 const configure = require('./configure')
+const labels = require('./labels')
 const orgs = require('./orgs')
 
 module.exports = trough()
   .use(configure)
+  .use(labels)
   .use(orgs)

--- a/lib/collective/labels.js
+++ b/lib/collective/labels.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const {scaleLinear} = require('d3-scale')
+const d3Color = require('d3-color')
+const {ascending} = require('alpha-sort')
+const toLabelSlug = require('../util/to-label-slug')
+
+module.exports = labels
+
+async function labels(ctx) {
+  const {ghLabels} = ctx
+  const remove = (ghLabels.remove || []).map(toLabelSlug)
+  const replace = {}
+  const add = []
+
+  ghLabels.add.forEach(x => (x.labels ? addAll : addOne)(x))
+
+  return {...ctx, ghLabels: {remove, replace, add}}
+
+  function addOne({legacy = [], color, ...x}) {
+    const slug = x.slug || toLabelSlug(x.name)
+
+    add.push({
+      ...x,
+      color: d3Color
+        .color(color)
+        .formatHex()
+        .slice(1),
+      slug
+    })
+
+    legacy.forEach(y => {
+      replace[toLabelSlug(y)] = slug
+    })
+  }
+
+  function addAll(group) {
+    const {labels, color} = group
+    let scale
+
+    if (color.from && color.to) {
+      scale = scaleLinear()
+        .domain([0, labels.length])
+        .range([color.from, color.to])
+    }
+
+    labels
+      .concat()
+      .map(x => ({...x, slug: toLabelSlug(x.name)}))
+      .sort((a, b) => ascending(a.slug, b.slug))
+      .forEach((x, i) => {
+        addOne({color: scale ? scale(i) : color, ...x})
+      })
+  }
+}

--- a/lib/repo/index.js
+++ b/lib/repo/index.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const trough = require('trough')
+const labels = require('./labels')
 const collaborators = require('./collaborators')
 
-module.exports = trough().use(collaborators)
+module.exports = trough()
+  .use(labels)
+  .use(collaborators)

--- a/lib/repo/labels.js
+++ b/lib/repo/labels.js
@@ -1,0 +1,301 @@
+'use strict'
+
+const chalk = require('chalk')
+const toLabelSlug = require('../util/to-label-slug')
+const {labelsPreviewAccept} = require('../util/constants')
+
+module.exports = labels
+
+const own = {}.hasOwnProperty
+const changeable = ['name', 'description', 'color']
+
+async function labels(info) {
+  const {repo, ctx} = info
+  const {ghLabels, org, ghQuery} = ctx
+  const {name, isArchived} = repo
+  const replaceMap = {...ghLabels.replace}
+
+  if (isArchived) {
+    return
+  }
+
+  console.log(chalk.bold('labels') + ' for %s', name)
+
+  const expected = ghLabels.add
+
+  const {repository} = await ghQuery(
+    `
+      query($org: String!, $name: String!) {
+        repository(owner: $org, name: $name) {
+          id
+          labels(first: 100) {
+            nodes {
+              id
+              name
+              description
+              color
+            }
+          }
+        }
+      }
+    `,
+    {org, name}
+  )
+
+  const repositoryId = repository.id
+
+  const prev = repository.labels.nodes.map(d => ({
+    ...d,
+    slug: toLabelSlug(d.name)
+  }))
+
+  const unknown = []
+  const remove = []
+  const actual = []
+  const toggle = []
+  const change = []
+
+  prev
+    .filter(d => !expected.find(e => d.slug === e.slug))
+    .forEach(d => {
+      if (own.call(replaceMap, d.slug)) {
+        const name = replaceMap[d.slug]
+        const replace = expected.find(e => e.slug === name)
+        const renameable =
+          !prev.find(e => e.slug === name) &&
+          !change.find(e => e.to.slug === name)
+        const list = renameable ? change : toggle
+
+        list.push({from: d, to: replace})
+      } else if (ghLabels.remove.includes(d.slug)) {
+        remove.push(d)
+      } else {
+        unknown.push(d)
+      }
+    })
+
+  // To do: add a scheme, e.g., `component/`, that’s free to use.
+  unknown.forEach(d => {
+    console.log(
+      '  ' + chalk.blue('ℹ') + ' unknown label ' + chalk.blue('%s'),
+      d.name
+    )
+  })
+
+  const add = expected
+    // Not already existing.
+    .filter(d => !prev.find(e => d.slug === e.slug))
+    // Not marked for a change.
+    .filter(d => !change.find(e => d.slug === e.to.slug))
+
+  if (add.length !== 0) {
+    const res = await ghQuery(
+      []
+        .concat(
+          'mutation {',
+          add.map(
+            (d, i) =>
+              '  create' +
+              i +
+              ': createLabel(input: { repositoryId: "' +
+              repositoryId +
+              '", name: "' +
+              d.name +
+              '", description: "' +
+              d.description +
+              '", color: "' +
+              d.color +
+              '" }) {\n    label { id }\n  }'
+          ),
+          '}'
+        )
+        .join('\n'),
+      {headers: {accept: labelsPreviewAccept}}
+    )
+
+    add.forEach((d, i) => {
+      actual.push({...d, id: res['create' + i].label.id})
+
+      console.log(
+        '  ' + chalk.green('✓') + ' created label %s',
+        chalk.blue(d.name)
+      )
+    })
+  }
+
+  prev
+    // Not added above.
+    .filter(d => !add.find(e => d.slug === e.slug))
+    .forEach(ac => {
+      const ex = expected.find(e => ac.slug === e.slug)
+
+      // Ignore unexpected values.
+      if (!ex) {
+        return
+      }
+
+      if (
+        ac.name === ex.name &&
+        ac.description === ex.description &&
+        ac.color === ex.color
+      ) {
+        actual.push(ac)
+      } else {
+        change.push({from: ac, to: ex})
+      }
+    })
+
+  if (change.length !== 0) {
+    await ghQuery(
+      []
+        .concat(
+          'mutation {',
+          change.map(
+            (d, i) =>
+              '  change' +
+              i +
+              ': updateLabel(input: { id: "' +
+              d.from.id +
+              '", name: "' +
+              d.to.name +
+              '", description: "' +
+              d.to.description +
+              '", color: "' +
+              d.to.color +
+              '" }) {\n    clientMutationId\n  }'
+          ),
+          '}'
+        )
+        .join('\n'),
+      {headers: {accept: labelsPreviewAccept}}
+    )
+
+    change.forEach(d => {
+      const diff = {}
+
+      changeable.forEach(p => {
+        if (d.from[p] !== d.to[p]) {
+          diff[p] = d.to[p]
+        }
+      })
+
+      actual.push({...d.to, id: d.from.id})
+
+      console.log(
+        '  ' +
+          chalk.green('✓') +
+          ' changed %s of label %s' +
+          (diff.name ? ' (now %s)' : ''),
+        Object.keys(diff).join(', '),
+        chalk.blue(d.from.name),
+        chalk.blue(d.to.name)
+      )
+    })
+  }
+
+  const toggleMap = toggle.reduce((all, d) => {
+    const to =
+      actual.find(e => e.slug === d.to.slug) ||
+      prev.find(e => e.slug === d.to.slug)
+
+    all[d.from.id] = to.id
+    return all
+  }, {})
+
+  const body = await ghQuery(
+    `
+      query($org: String!, $name: String!, $labels: [String!]) {
+        repository(owner: $org, name: $name) {
+          issues(labels: $labels, first: 100) {
+            nodes {
+              id
+              title
+              labels(first: 100) { nodes { id } }
+            }
+          }
+          pullRequests(labels: $labels, first: 100) {
+            nodes {
+              id
+              title
+              labels(first: 100) { nodes { id } }
+            }
+          }
+        }
+      }
+    `,
+    {org, name, labels: toggle.map(d => d.from.name)}
+  )
+
+  const mutations = []
+
+  body.repository.issues.nodes
+    .concat(body.repository.pullRequests.nodes)
+    .forEach(d => {
+      const labels = d.labels.nodes.map(e => e.id)
+      const add = labels
+        .filter(e => own.call(toggleMap, e) && !labels.includes(toggleMap[e]))
+        .map(e => toggleMap[e])
+
+      if (add.length !== 0) {
+        mutations.push({issue: d.id, title: d.title, labels: add})
+      }
+    })
+
+  if (mutations.length !== 0) {
+    await ghQuery(
+      []
+        .concat(
+          'mutation {',
+          mutations.map((d, i) => {
+            return `  mut${i}: addLabelsToLabelable(input: { labelableId: ${JSON.stringify(
+              d.issue
+            )}, labelIds: ${JSON.stringify(d.labels)} }) { clientMutationId }`
+          }),
+          '}'
+        )
+        .join('\n')
+    )
+
+    mutations.forEach(d => {
+      console.log(
+        '  ' +
+          chalk.green('✓') +
+          ' added ' +
+          d.labels.length +
+          ' label' +
+          (d.labels.length === 1 ? '' : 's') +
+          ' to ' +
+          chalk.blue('%s'),
+        d.title
+      )
+    })
+  }
+
+  // Add the toggled labels to the remove list.
+  toggle.forEach(d => {
+    remove.push(d.from)
+  })
+
+  if (remove.length !== 0) {
+    await ghQuery(
+      []
+        .concat(
+          'mutation {',
+          remove.map(
+            (d, i) =>
+              `  remove${i}: deleteLabel(input: { id: "${d.id}" }) { clientMutationId }`
+          ),
+          '}'
+        )
+        .join('\n'),
+      {headers: {accept: labelsPreviewAccept}}
+    )
+
+    remove.forEach(d => {
+      console.log(
+        '  ' + chalk.green('✓') + ' removed label ' + chalk.blue('%s'),
+        d.name
+      )
+    })
+  }
+}

--- a/lib/repo/labels.js
+++ b/lib/repo/labels.js
@@ -95,17 +95,7 @@ async function labels(info) {
           'mutation {',
           add.map(
             (d, i) =>
-              '  create' +
-              i +
-              ': createLabel(input: { repositoryId: "' +
-              repositoryId +
-              '", name: "' +
-              d.name +
-              '", description: "' +
-              d.description +
-              '", color: "' +
-              d.color +
-              '" }) {\n    label { id }\n  }'
+              `  create${i}: createLabel(input: { repositoryId: "${repositoryId}", name: "${d.name}", description: "${d.description}", color: "${d.color}" }) {\n    label { id }\n  }`
           ),
           '}'
         )
@@ -152,17 +142,7 @@ async function labels(info) {
           'mutation {',
           change.map(
             (d, i) =>
-              '  change' +
-              i +
-              ': updateLabel(input: { id: "' +
-              d.from.id +
-              '", name: "' +
-              d.to.name +
-              '", description: "' +
-              d.to.description +
-              '", color: "' +
-              d.to.color +
-              '" }) {\n    clientMutationId\n  }'
+              `  change ${i}: updateLabel(input: { id: "${d.from.id}", name: "${d.to.name}", description: "${d.to.description}", color: "${d.to.color}" }) {\n    clientMutationId\n  }`
           ),
           '}'
         )

--- a/lib/repo/labels.js
+++ b/lib/repo/labels.js
@@ -142,7 +142,7 @@ async function labels(info) {
           'mutation {',
           change.map(
             (d, i) =>
-              `  change ${i}: updateLabel(input: { id: "${d.from.id}", name: "${d.to.name}", description: "${d.to.description}", color: "${d.to.color}" }) {\n    clientMutationId\n  }`
+              `  change${i}: updateLabel(input: { id: "${d.from.id}", name: "${d.to.name}", description: "${d.to.description}", color: "${d.to.color}" }) {\n    clientMutationId\n  }`
           ),
           '}'
         )

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -1,4 +1,4 @@
 'use strict'
 
 exports.childTeamAccept = 'application/vnd.github.hellcat-preview+json'
-exports.dependencyGraphAccept = 'application/vnd.github.hawkgirl-preview+json'
+exports.labelsPreviewAccept = 'application/vnd.github.bane-preview+json'

--- a/lib/util/to-label-slug.js
+++ b/lib/util/to-label-slug.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = toLabelSlug
+
+function toLabelSlug(value) {
+  return (
+    value
+      // Remove Gemoji shortcodes
+      .replace(/:[^:]+:/g, '')
+      // Remove non-ASCII
+      // eslint-disable-next-line no-control-regex
+      .replace(/[^\u0000-\u007F]/g, '')
+      // Replace dash and underscore with a space.
+      .replace(/[-_]/g, ' ')
+      // Replace multiple spaces
+      .replace(/\s/g, ' ')
+      // Trim.
+      .trim()
+  )
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "unist-builder": "^1.0.0"
   },
   "devDependencies": {
+    "alpha-sort": "^3.0.0",
+    "d3-color": "^1.3.0",
+    "d3-scale": "^3.0.1",
     "prettier": "^1.0.0",
     "remark-cli": "^7.0.0",
     "remark-preset-wooorm": "^6.0.0",


### PR DESCRIPTION
This commit adds support for automating the labels across all organizations in the unified collective.  The GitHub label defaults are broad and not very useful.  These labels are specific to our needs.

This comes with a defined structure of labels that are useful to our collective.  They come in groups of area, platform, semver, status, type, and there are a couple of miscellaneous labels.

The tooling now warns for unexpected labels, adds missing labels, fixes incorrect names, colors, and descriptions, replaces old labels with new on existing issues and pull requests, and removes legacy labels.

One cool extra is that the structured labels support automating color scaling for groups!

Closes GH-4.